### PR TITLE
Fix OCR text extraction issues

### DIFF
--- a/backend/src/services/ocr.service.ts
+++ b/backend/src/services/ocr.service.ts
@@ -28,8 +28,8 @@ class OcrService {
       
       // Get text blocks from the result
       if (result.data.text) {
-        // Split text into blocks by newlines and spaces
-        const blocks = result.data.text.split(/[\n\s]+/).filter(Boolean);
+        // Sửa: chỉ tách theo xuống dòng, mỗi content là một dòng đầy đủ
+        const blocks = result.data.text.split('\n').map((line: string) => line.trim()).filter(Boolean);
         
         blocks.forEach((text, index) => {
           contents.push({
@@ -44,6 +44,8 @@ class OcrService {
             }
           });
         });
+        // Thêm log debug toàn bộ content
+        console.log('[DEBUG][OCR] Toàn bộ content sau khi tách dòng:', contents);
       }
 
       const processingTime = Date.now() - startTime;


### PR DESCRIPTION
Fix OCR content extraction by splitting text into full lines instead of individual words to improve field matching accuracy.

Previously, OCR text was split by both newlines and spaces, resulting in single-word content blocks. This caused the fuzzy matching algorithm to frequently pick 'Ta' (from 'May Home Ta Xua') for various fields, leading to incorrect data extraction. By splitting only by newlines, each content block now represents a full line, significantly improving the accuracy of field mapping. A debug log for the extracted content has also been added.