### PR TITLE
Fix this error

### DIFF
--- a/backend/src/controllers/ocr-form.controller.ts
+++ b/backend/src/controllers/ocr-form.controller.ts
@@ -280,9 +280,16 @@ class OcrFormController {
             });
           }
         }
+        // Kiểm tra supplierId hợp lệ
+        if (!supplierId || isNaN(Number(supplierId))) {
+          return res.status(400).json({
+            success: false,
+            message: 'Thiếu hoặc sai định dạng ID nhà cung cấp'
+          });
+        }
         const importData: any = {
           date: fields.find(f => f.name === 'date')?.value || new Date(),
-          supplierId,
+          supplierId: Number(supplierId),
           invoiceNumber: fields.find(f => f.name === 'invoice_no')?.value || '',
           processedById: userId,
           totalAmount: fields.find(f => f.name === 'total')?.value || 0,


### PR DESCRIPTION
Add validation for `supplierId` in OCR form confirmation to prevent Prisma errors.

This PR addresses a `PrismaClientValidationError` where `supplierId` could be `null` or an invalid number, causing `prisma.supplier.findUnique()` to fail. It now validates `supplierId` and converts it to a number before use.