### PR TITLE
Fix persistent bug

### DIFF
--- a/backend/jest.config.ts
+++ b/backend/jest.config.ts
@@ -9,7 +9,9 @@ const config: Config.InitialOptions = {
     '**/?(*.)+(spec|test).+(ts|tsx|js)'
   ],
   transform: {
-    '^.+\\.(ts|tsx)$': 'ts-jest'
+    '^.+\\.(ts|tsx)$': ['ts-jest', {
+      tsconfig: 'tsconfig.test.json'
+    }]
   },
   setupFilesAfterEnv: ['<rootDir>/src/tests/setup.ts'],
   moduleNameMapper: {

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -21,8 +21,7 @@
       "./src/types"
     ],
     "types": [
-      "node",
-      "jest"
+      "node"
     ],
     "noImplicitAny": false,
     "strictPropertyInitialization": false,
@@ -39,5 +38,5 @@
     "allowSyntheticDefaultImports": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts", "src/tests", "jest.config.ts"]
 }

--- a/backend/tsconfig.test.json
+++ b/backend/tsconfig.test.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": [
+      "node",
+      "jest"
+    ]
+  },
+  "include": [
+    "src/**/*",
+    "src/tests/**/*"
+  ],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Separate Jest type definitions into a dedicated `tsconfig.test.json` to resolve TypeScript build errors.

This fixes a TypeScript error where Jest type definitions were being loaded during production builds, causing build failures. By separating the test configuration, the production build process is now clean and free of unnecessary type dependencies.